### PR TITLE
add .git ignore with full disregards and project specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,136 @@
+# Project #
+###########
+mycroft-qtapplication.pro.use*
+
+# Prerequisites #
+#################
+*.d
+
+# Object files #
+################
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output #
+#################
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers #
+#######################
+*.gch
+*.pch
+
+# Libraries #
+#############
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs) #
+######################################
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables #
+###############
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files #
+###############
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.AppImage
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+
+# OSX | macOS #
+.DS_Store
+.DS_Store?
+._*
+.AppleDouble
+.LSOverride
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows #
+.db
+ehthumbs.db
+ehthumbs_vista.db
+# Folder config file
+Desktop.ini
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+# Windows shortcuts
+*.lnkhumbs.db
+
+# Miscellaneous #
+#################
+*.orig
+*.rej
+
+# EMACS #
+#########
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Vim #
+#######
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~


### PR DESCRIPTION
Add an extremely comprehensive `.gitignore`

This solves the `.AppImage` problem as well as any temp compiling files like `mycroft-qtapplication.pro.use*`